### PR TITLE
#705: Fix broken links to the DDI specifications, state that DDI Lifecycle is a supported format

### DIFF
--- a/detailed-study-view.md
+++ b/detailed-study-view.md
@@ -55,7 +55,7 @@ This is the JSON view in Safari, with a JSON formatting extension.
 
 ## Installing a JSON formatting extension
 
-For Chrome, see the [Install and manage extensions](https://support.google.com/chrome_webstore/answer/2664769?hl=en)
+For Chrome, see the [Install and manage extensions](https://support.google.com/chrome_webstore/answer/2664769)
 help page. 'JSON Viewer' is one of the available extensions for Chrome.
 
 For Safari, see the [How to install Safari extensions on your Mac](https://support.apple.com/en-us/HT203051)

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ nav_order: 000
 
 # {{ page.title }}
 
-This is the User Guide for version 3.7.0 of the CESSDA Data Catalogue.
+This is the User Guide for version 3.8.0 of the CESSDA Data Catalogue.
 
 The CESSDA Data Catalogue contains descriptions (metadata) of the more than 40,000 data collections
 held by CESSDA’s Service Providers (SPs).

--- a/oai-pmh-api.md
+++ b/oai-pmh-api.md
@@ -24,7 +24,7 @@ Metadata is provided in the formats
 
 The endpoint offers common OAI-PMH functionality:
 
-- Selective harvesting with Sets & Datestamps
+- Selective harvesting with Sets & Date stamps
 - List request sequence with ResumptionTokens
 - OAI-Identifiers
 - Deleted records

--- a/providing-oai-pmh.md
+++ b/providing-oai-pmh.md
@@ -9,7 +9,7 @@ nav_order: 071
 
 # {{ page.title }}
 
-CESSDA DC metadata is based on [DDI Codebook](https://ddialliance.org/Specification/DDI-Codebook/2.5/) and exchanged using [OAI-PMH](https://www.openarchives.org/pmh/).
+CESSDA DC metadata is based on [DDI Codebook](https://ddialliance.org/ddi-codebook) and [DDI Lifecycle](https://ddialliance.org/ddi-lifecycle) and is harvested using [OAI-PMH](https://www.openarchives.org/pmh/).
 
 The metadata is expected to be compliant with the [CESSDA Metadata Model v1.0](https://zenodo.org/record/3543756).
 Specifically, the [CESSDA Metadata Profiles](https://cmv.cessda.eu/documentation/profiles.html) must be adopted.

--- a/providing-oai-pmh.md
+++ b/providing-oai-pmh.md
@@ -9,7 +9,8 @@ nav_order: 071
 
 # {{ page.title }}
 
-CESSDA DC metadata is based on [DDI Codebook](https://ddialliance.org/ddi-codebook) and [DDI Lifecycle](https://ddialliance.org/ddi-lifecycle) and is harvested using [OAI-PMH](https://www.openarchives.org/pmh/).
+CESSDA DC metadata is based on [DDI Codebook](https://ddialliance.org/ddi-codebook) and [DDI Lifecycle](https://ddialliance.org/ddi-lifecycle)
+and is harvested using [OAI-PMH](https://www.openarchives.org/pmh/).
 
 The metadata is expected to be compliant with the [CESSDA Metadata Model v1.0](https://zenodo.org/record/3543756).
 Specifically, the [CESSDA Metadata Profiles](https://cmv.cessda.eu/documentation/profiles.html) must be adopted.


### PR DESCRIPTION
This closes cessda/cessda.cdc.versions#705